### PR TITLE
Add useHooks(🐠)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)
 - [CodeSandbox Starter Kit](https://codesandbox.io/s/7y6o4282lq)
 - [Searchable Collection of React Hooks](https://nikgraf.github.io/react-hooks/)
+- [useHooks(🐠)](https://usehooks.com/) One new React Hook recipe every day.
 
 ## Packages
 


### PR DESCRIPTION
Not sure about where to place this link (https://usehooks.com/), it's not a code tool. Maybe a new section and move https://nikgraf.github.io/react-hooks/ with it?

Any thoughts @jamiebuilds?