### PR TITLE
Add react-use-idb

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [`react-selector-hooks`](https://github.com/Andarist/react-selector-hooks) Collection of hook-based memoized selector factories for declarations outside of render.
 - [`react-use`](https://github.com/streamich/react-use) Collection of essential hooks.
 - [`react-use-form-state`](https://github.com/wsmd/react-use-form-state) React hook for managing form and inputs state.
+- [`react-use-idb`](https://github.com/kigiri/react-use-idb) React hook for storing value in the browser using `indexDB`.
 - [`react-window-communication-hook`](https://github.com/AvraamMavridis/react-window-communication-hook) React hook to communicate among browser contexts (tabs, windows, iframes).
 - [`react-with-hooks`](https://github.com/yesmeck/react-with-hooks) Ponyfill for the proposed React Hooks API.
 - [`redux-react-hook`](https://github.com/ianobermiller/redux-react-hook) React hook for accessing mapped state from a Redux store.


### PR DESCRIPTION
React side-effect hook that manages a single indexDB item.

[`react-use-idb`](https://github.com/kigiri/react-use-idb) 

Used for storing state in the browser.
A drop-in remplacement over `useLocalStorage`.

