### PR TITLE
adding use-socketio

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@
 - [`use-substate`](https://github.com/philipp-spiess/use-substate) React hook for subscribing to your single app state (works with your current [Redux](https://redux.js.org/) app).
 - [`use-undo`](https://github.com/xxhomey19/use-undo) React hook to implement Undo and Redo functionality.
 - [`usePosition`](https://github.com/tranbathanhtung/usePosition) React hook to get position top left of an element.
+- [`use-socketio`](https://github.com/mfrachet/use-socketio) React hooks to use with https://socket.io/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [`use-events`](https://github.com/sandiiarov/use-events) A set of React Hooks to handle mouse events.
 - [`use-immer`](https://github.com/mweststrate/use-immer) A hook to use [immer](https://github.com/mweststrate/immer) to manipulate state.
 - [`use-simple-undo`](https://github.com/sandiiarov/use-simple-undo) Simple implementation of undo/redo functionality.
+- [`use-socketio`](https://github.com/mfrachet/use-socketio) React hooks to use with https://socket.io/.
 - [`use-substate`](https://github.com/philipp-spiess/use-substate) React hook for subscribing to your single app state (works with your current [Redux](https://redux.js.org/) app).
 - [`use-undo`](https://github.com/xxhomey19/use-undo) React hook to implement Undo and Redo functionality.
 - [`usePosition`](https://github.com/tranbathanhtung/usePosition) React hook to get position top left of an element.
-- [`use-socketio`](https://github.com/mfrachet/use-socketio) React hooks to use with https://socket.io/


### PR DESCRIPTION
Adding `use-socketio` which is a hook that allows the use of socketio really easily inside an app.

Here's an exemple using the officiel `socket.io` websocket API for live tweets:

- https://github.com/mfrachet/use-socketio
- https://mfrachet.github.io/use-socketio/