### PR TITLE
Add hooks.macro Babel Macro tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 ## Tools
 
 - [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)
+- [`hooks.macro`](https://www.npmjs.com/package/hooks.macro) Babel Macros for automatic memoization invalidation
 - [CodeSandbox Starter Kit](https://codesandbox.io/s/7y6o4282lq)
 - [React Hooks Snippets for VS Code](https://marketplace.visualstudio.com/items?itemName=antmdvs.vscode-react-hooks-snippets)
 


### PR DESCRIPTION
I placed it in the Tools section, since it’s not a Hook-exposing package — but I feel a little bit embarassed to place it as the only non-official item in that list.