### PR TITLE
Add Examples section with Material-UI PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,6 @@
 - [`usePosition`](https://github.com/tranbathanhtung/usePosition) React hook to get position top left of an element.
 - [`useScreenType`](https://github.com/pankod/react-hooks-screen-type) Determining screen size type for Bootstrap 4 grid.
 - [`useScrollSpy`](https://github.com/Purii/react-use-scrollspy) React hook to automatically update navigation based on scroll position.
+
+## Examples
+- [`material-ui`](https://github.com/mui-org/material-ui/pull/13497) Material-UI demos powered by React Hooks.


### PR DESCRIPTION
Share the Material-UI examples which are now powered by React Hooks.