### PR TITLE
Add link to `withHooksSupport` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [`hooks.macro`](https://www.npmjs.com/package/hooks.macro) Babel Macros for automatic memoization invalidation
 - [CodeSandbox Starter Kit](https://codesandbox.io/s/7y6o4282lq)
 - [React Hooks Snippets for VS Code](https://marketplace.visualstudio.com/items?itemName=antmdvs.vscode-react-hooks-snippets)
+- [`withHooksSupport`](https://www.npmjs.com/package/with-hooks-support) HOC for adding hooks support to class components.
 
 ## Catalogs
 


### PR DESCRIPTION
`withHooksSupport` is a Higher-order component for adding hooks support to class components.

https://github.com/mDibyo/with-hooks-support
```jsx
class FancyInput extends React.Component {
  render() {
    // `useFormInput` returns an object with `value` and `onChange` attributes.
    const inputProps = useFormInput();

    return <input {...inputProps} />;
  }
}

export default withHooksSupport(FancyInput);
```

Useful while migrating over an existing React code base with class components, to function components with hooks.

Thanks!