### PR TITLE
Replace withHooksSupport with hook-into-props

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [`hooks.macro`](https://www.npmjs.com/package/hooks.macro) Babel Macros for automatic memoization invalidation
 - [CodeSandbox Starter Kit](https://codesandbox.io/s/7y6o4282lq)
 - [React Hooks Snippets for VS Code](https://marketplace.visualstudio.com/items?itemName=antmdvs.vscode-react-hooks-snippets)
-- [`withHooksSupport`](https://www.npmjs.com/package/with-hooks-support) HOC for adding hooks support to class components.
+- [`hook-into-props`](https://github.com/juliettepretot/hook-into-props/tree/1e069a6c01c2a783100f2fea7709f56d8166a97e) Helper to build HOCs using hooks. Useful for using hooks with class components.
 - [`react-universal-hooks`](https://github.com/salvoravida/react-universal-hooks) React Universal Hooks: just use****** everywhere, Functional or Class Components 
 - [Jooks](https://github.com/antoinejaussoin/jooks) Unit-test your custom hooks by mocking React's Hooks API (useState, etc.)
 


### PR DESCRIPTION
withHooksSupport relies on [mutating the passed Component's render method](https://github.com/mDibyo/with-hooks-support/blob/master/src/index.js). The React documentation explicitly [warns against this](https://reactjs.org/docs/higher-order-components.html#dont-mutate-the-original-component-use-composition). Instead of mutation, composition is recommended, which is the approach taken by [hook-into-props](https://github.com/juliettepretot/hook-into-props/): 

Secondly, the fact that hooks must be called within the class components render method limits its usefulness. We won't have access to the hook results in any of our other class methods. :) 

I love the simplicity of `withHooksSupport`, but I'd strongly caution against recommending it for any production application.