### PR TITLE
add react-swipeable swipe hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [`react-selector-hooks`](https://github.com/Andarist/react-selector-hooks) Collection of hook-based memoized selector factories for declarations outside of render.
 - [`react-speech-kit`](https://github.com/MikeyParton/react-speech-kit) Hooks for browser Speech Recognition and Speech Synthesis.
 - [`react-state-patterns`](https://github.com/mcclayton/react-state-patterns) Utility package for creating reusable implementations of React state provider patterns from hooks.
+- [`react-swipeable`](https://github.com/dogfessional/react-swipeable) React swipe event handler hook.
 - [`react-use-calendar`](https://github.com/gregnb/react-use-calendar) A hook for implementing a calendar with events.
 - [`react-use-clipboard`](https://github.com/danoc/react-use-clipboard) A hook that copies text to a user's clipboard.
 - [`react-use-data-loader`](https://github.com/smmoosavi/react-use-data-loader) React hook for loading data


### PR DESCRIPTION
- add [react-swipeable](https://github.com/dogfessional/react-swipeable) reference which has a `useSwipeable` hook that supplies handlers to track "swipe" events.