### PR TITLE
Add Captain hook to catalogs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 ## Catalogs
 
 - [@umijs/hooks(🍚)](https://github.com/umijs/hooks/) A collection of React Hooks specifically aiming at enterprise applications.
+- [Captain hook](https://github.com/stevenpersia/captain-hook) Modest list of hooks.
 - [crooks](https://github.com/chrisjpatty/crooks) A collection of unique React Hooks.
 - [hooks-by-example](https://github.com/latviancoder/hooks-by-example) Collection of beginner-friendly real world examples of hook usage.
 - [Hooks.guide](https://www.hooks.guide/) Collection of React hooks curated by the community.


### PR DESCRIPTION
This adds captain-hook from stevenpersia to the list of catalogs.

Have a look at the catalog here: https://github.com/stevenpersia/captain-hook