### PR TITLE
Add useScreenType to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,4 +239,4 @@
 - [`useScrollSpy`](https://github.com/Purii/react-use-scrollspy) React hook to automatically update navigation based on scroll position.
 - [`useServiceWorker`](https://github.com/JCofman/react-hook-use-service-worker) A React hook which can register a service worker
 - [`useValueAfter`](https://github.com/bboydflo/use-value-after) Very simple React hook to easily provide different props to a component (comes in handy for testing edge cases)
-
+- [`useScreenType`](https://github.com/wednesday-solutions/react-screentype-hook) React hook to dynamically get current screen type (mobile, tablet, desktop) with configurable breakpoint support.


### PR DESCRIPTION
(https://github.com/wednesday-solutions/react-screentype-hook): React hook to dynamically get current screen type (mobile, tablet, desktop) with configurable breakpoint support.