### PR TITLE
Add use-scroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
 - [`use-reactive-state`](https://github.com/tedstoychev/use-reactive-state) `useReactiveState()` - a reactive alternative to React's `useState()`.
 - [`use-reducer-async`](https://github.com/dai-shi/use-reducer-async) React useReducer with async actions
 - [`use-redux`](https://github.com/flepretre/use-redux) A hook to bind [redux](https://redux.js.org).
+- [`use-scroller`](https://github.com/geobde/use-scroller) React hook that automatically adds the next page, saving users from a full page load.
 - [`use-scroll-to-bottom`](https://github.com/tudorgergely/use-scroll-to-bottom) React hook for detecting when an element was scrolled to bottom.
 - [`use-simple-undo`](https://github.com/sandiiarov/use-simple-undo) Simple implementation of undo/redo functionality.
 - [`use-socketio`](https://github.com/mfrachet/use-socketio) React hooks to use with https://socket.io/.


### PR DESCRIPTION
React hook useScroller() that automatically adds the next page, saving users from a full page load, lightweight and with no other dependencies.