### PR TITLE
docs: Add the React Hooks update Syntax episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@
 
 ## Podcasts
 
-- [React Hooks - Syntax](https://syntax.fm/show/092/react-hooks)
-- [React Hooks 1 Year Later - Syntax](https://syntax.fm/show/232/react-hooks-1-year-later)
+- [React Hooks - Syntax (Nov 14th, 2018)](https://syntax.fm/show/092/react-hooks)
+- [React Hooks 1 Year Later - Syntax (Mar 18, 2020)](https://syntax.fm/show/232/react-hooks-1-year-later)
+- [Why should I use React Hooks? - Syntax (Dec 7th, 2020)](https://syntax.fm/show/307/hasty-treat-why-should-i-use-react-hooks)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ## Podcasts
 
 - [React Hooks - Syntax](https://syntax.fm/show/092/react-hooks)
+- [React Hooks 1 Year Later - Syntax](https://syntax.fm/show/232/react-hooks-1-year-later)
 
 ## Tools
 


### PR DESCRIPTION
Since the original Syntax episode is already there, I thought that the update episode could be added.

There's also a shorter episode that's even more recent as well

I'm not sure if it should be added as well

https://syntax.fm/show/307/hasty-treat-why-should-i-use-react-hooks