### PR TITLE
Remove use-hooks.org link which is dead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@
 - [Searchable Collection of React Hooks](https://nikgraf.github.io/react-hooks/)
 - [Sunflower(🌻)](https://github.com/ant-design/sunflower) Collection of React Hooks returning components of antd.
 - [useHooks(🐠)](https://usehooks.com/) One new React Hook recipe every day.
-- [Use Hooks](https://use-hooks.org/) A collection of reusable React Hooks.
 
 ## Packages
 


### PR DESCRIPTION
No alternative available.