### PR TITLE
add react hook: use-valid-input

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@
 - [`useScreenType`](https://github.com/wednesday-solutions/react-screentype-hook) React hook to dynamically get current screen type (mobile, tablet, desktop) with configurable breakpoint support.
 - [`useScrollSpy`](https://github.com/Purii/react-use-scrollspy) React hook to automatically update navigation based on scroll position.
 - [`useServiceWorker`](https://github.com/JCofman/react-hook-use-service-worker) A React hook which can register a service worker
+- [`useValidInput`](https://github.com/phazelift/use-valid-input) React hook for easy and solid input validation
 - [`useValueAfter`](https://github.com/bboydflo/use-value-after) Very simple React hook to easily provide different props to a component (comes in handy for testing edge cases)
 - [`useWaitForElements`](https://github.com/renansoares/useWaitForElements) A simple hook to wait for elements to be rendered with MutationObserver.
 - [`useWindowOrientation`](https://github.com/tywmick/use-window-orientation) A hook returning the window's orientation (portrait vs. landscape) based off of current window dimensions


### PR DESCRIPTION
Hi, I've made a react hook for easy and solid input validation: <a href='https://www.npmjs.com/package/use-valid-input'>use-valid-input</a>. Would be nice if it would be added to this list.